### PR TITLE
mcp: keep local skill search lightweight and refreshable

### DIFF
--- a/openspace/mcp_server.py
+++ b/openspace/mcp_server.py
@@ -104,7 +104,6 @@ mcp = FastMCP("OpenSpace", **_fastmcp_kwargs)
 _openspace_instance = None
 _openspace_lock = asyncio.Lock()
 _standalone_store = None
-_local_skill_registry = None
 
 # Internal state: tracks bot skill directories already registered this session.
 _registered_skill_dirs: set = set()
@@ -190,11 +189,9 @@ def _get_local_skill_registry():
     This avoids initializing the full OpenSpace engine when callers only
     want to inspect local skills. It mirrors the skill directory discovery
     order used by the full engine, but skips LLM / provider startup.
+    The registry is rebuilt per call so later local searches can see
+    newly added skills without requiring a process restart.
     """
-    global _local_skill_registry
-    if _local_skill_registry is not None:
-        return _local_skill_registry
-
     from openspace.config import get_config
     from openspace.skill_engine import SkillRegistry
 
@@ -238,7 +235,6 @@ def _get_local_skill_registry():
 
     registry = SkillRegistry(skill_dirs=skill_paths)
     registry.discover()
-    _local_skill_registry = registry
     return registry
 
 

--- a/tests/test_issue3_startup.py
+++ b/tests/test_issue3_startup.py
@@ -47,3 +47,72 @@ Find me when querying demo local skill.
         item["name"] == "Demo Local Skill"
         for item in payload["results"]
     )
+
+
+@pytest.mark.asyncio
+async def test_local_search_skills_refreshes_registry_between_calls(monkeypatch, tmp_path):
+    skill_root = tmp_path / "skills"
+    first_skill_dir = skill_root / "first-local-skill"
+    first_skill_dir.mkdir(parents=True)
+    (first_skill_dir / "SKILL.md").write_text(
+        """---
+name: First Local Skill
+description: First local skill for cache regression coverage
+---
+
+First local skill content.
+""",
+        encoding="utf-8",
+    )
+
+    async def forbidden_get_openspace():
+        pytest.fail("_get_openspace should not run for source='local'")
+
+    monkeypatch.setenv("OPENSPACE_HOST_SKILL_DIRS", str(skill_root))
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.setattr(mcp_server, "_get_openspace", forbidden_get_openspace)
+    monkeypatch.setattr(
+        "openspace.cloud.embedding.generate_embedding",
+        lambda text, api_key=None: None,
+    )
+
+    first_response = await mcp_server.search_skills(
+        query="first local skill",
+        source="local",
+        limit=5,
+        auto_import=False,
+    )
+
+    first_payload = json.loads(first_response)
+    assert any(
+        item["name"] == "First Local Skill"
+        for item in first_payload["results"]
+    )
+
+    second_skill_dir = skill_root / "second-local-skill"
+    second_skill_dir.mkdir(parents=True)
+    (second_skill_dir / "SKILL.md").write_text(
+        """---
+name: Second Local Skill
+description: Second local skill created after the first search
+---
+
+Second local skill content.
+""",
+        encoding="utf-8",
+    )
+
+    second_response = await mcp_server.search_skills(
+        query="second local skill",
+        source="local",
+        limit=5,
+        auto_import=False,
+    )
+
+    second_payload = json.loads(second_response)
+    assert any(
+        item["name"] == "Second Local Skill"
+        for item in second_payload["results"]
+    )


### PR DESCRIPTION
Fixes #3

## Summary
Keep `search_skills(source="local")` on the lightweight path, but rebuild the local `SkillRegistry` on each local-only search so newly added skills become visible without restarting the process.

## What did NOT change
This PR does not rename packages, does not refactor the full startup path, and does not change the `source="all"` execution path.

## User-visible changes
Local-only skill search no longer depends on full OpenSpace initialization.
A second local search in the same process can now discover newly added local skills.

## Compatibility / Security impact
No API surface change.
The tradeoff is that local-only search now rescans local skill directories per call instead of reusing a stale in-process snapshot.

## Test plan
- [x] Reproduced the stale-registry issue with `pytest -q tests/test_issue3_startup.py` before the freshness fix
- [x] Verified the no-startup path still forbids `_get_openspace()` for `source="local"`
- [x] Ran `pytest -q tests/test_issue3_startup.py` after the fix and got `2 passed`
- [x] Reran `pytest -q tests/test_issue3_startup.py` after the final commit and got `2 passed`

## Evidence / Actual results
Before the freshness fix, the new regression test failed while the no-startup test still passed.
After the fix, `pytest -q tests/test_issue3_startup.py` passed with `2 passed`.
A post-commit rerun also passed with `2 passed`.

## Human verification
Reviewed the final diff to confirm the change stayed scoped to `openspace/mcp_server.py` and `tests/test_issue3_startup.py`.
Confirmed the local-only path still avoids `_get_openspace()`.

## Risks / rollback
Very large local skill trees will pay the discovery cost on each local-only search.
If that tradeoff is unacceptable, the next step would be a scoped invalidation strategy rather than a broader startup refactor.
