### PR TITLE
fix: replace ErrorCode enum calls with GroundingError raises

### DIFF
--- a/openspace/grounding/core/grounding_client.py
+++ b/openspace/grounding/core/grounding_client.py
@@ -337,13 +337,13 @@ class GroundingClient:
     def get_session_info(self, name: str) -> SessionInfo:
         """Get session monitoring info"""
         if name not in self._session_info:
-            raise ErrorCode.SESSION_NOT_FOUND(name)
+            raise GroundingError(f"Session not found: {name}", code=ErrorCode.SESSION_NOT_FOUND)
         return self._session_info[name]
     
     def get_session(self, name: str) -> BaseSession:
         """Get session"""
         if name not in self._sessions:
-            raise ErrorCode.SESSION_NOT_FOUND(name)
+            raise GroundingError(f"Session not found: {name}", code=ErrorCode.SESSION_NOT_FOUND)
         return self._sessions[name]
     
     
@@ -479,7 +479,7 @@ class GroundingClient:
         # Session-level
         if session_name:                  
             if session_name not in self._sessions:
-                raise ErrorCode.SESSION_NOT_FOUND(session_name)
+                raise GroundingError(f"Session not found: {session_name}", code=ErrorCode.SESSION_NOT_FOUND)
             backend_type = self._session_info[session_name].backend_type
             return await self._fetch_tools(
                 backend_type,
@@ -531,7 +531,7 @@ class GroundingClient:
         use_cache: bool = False
     ) -> list[BaseTool]:
         if session_name not in self._session_info:
-            raise ErrorCode.SESSION_NOT_FOUND(session_name)
+            raise GroundingError(f"Session not found: {session_name}", code=ErrorCode.SESSION_NOT_FOUND)
         backend = self._session_info[session_name].backend_type
         return await self.list_tools(backend, session_name, use_cache)
 
@@ -838,7 +838,7 @@ class GroundingClient:
                     runtime_backend = backend
                 else:
                     if runtime_session not in self._session_info:
-                        raise ErrorCode.SESSION_NOT_FOUND(runtime_session)
+                        raise GroundingError(f"Session not found: {runtime_session}", code=ErrorCode.SESSION_NOT_FOUND)
                     runtime_backend = self._session_info[
                         runtime_session
                     ].backend_type


### PR DESCRIPTION
## Summary

- Fix 5 runtime `TypeError` crashes where `ErrorCode` enum members were called as constructors (`ErrorCode.SESSION_NOT_FOUND(name)`) — enum members are not callable
- Replace all occurrences with proper `GroundingError(message, code=ErrorCode.SESSION_NOT_FOUND)` raises

## Affected locations

| Method | Line |
|--------|------|
| `get_session_info` | 340 |
| `get_session` | 346 |
| `list_tools` (session path) | 482 |
| `list_session_tools` | 534 |
| `invoke_tool` (runtime session) | 841 |

## Test plan

- [ ] Verify `get_session("nonexistent")` raises `GroundingError` with `code=ErrorCode.SESSION_NOT_FOUND`
- [ ] Verify `get_session_info("nonexistent")` raises `GroundingError`
- [ ] Verify callers catching `GroundingError` still work as expected

Closes #11

Made with [Cursor](https://cursor.com)