### PR TITLE
fix: add missing Logger.set_level() method

### DIFF
--- a/openspace/utils/logging.py
+++ b/openspace/utils/logging.py
@@ -234,6 +234,14 @@ class Logger:
             cls._configured = True
 
     @classmethod
+    def set_level(cls, level: str) -> None:
+        """Set log level by name (e.g. ``"DEBUG"``, ``"INFO"``, ``"WARNING"``)."""
+        resolved = getattr(logging, level.upper(), None)
+        if resolved is None or not isinstance(resolved, int):
+            raise ValueError(f"Unknown log level: {level!r}")
+        cls.configure(level=resolved, force=True)
+
+    @classmethod
     def set_debug(cls, debug_level: int = 2) -> None:
         """Dynamically switch debug level: 0 = WARNING, 1 = INFO, 2 = DEBUG."""
         global OPENSPACE_DEBUG


### PR DESCRIPTION
## Summary

- Add `Logger.set_level(level: str)` class method that was missing but called from `__main__.py` when `--log-level` CLI flag is used
- Resolves level name string (e.g. `"DEBUG"`) to `logging` constant, validates it, and applies via `configure(force=True)`

## Root cause

`__main__.py:355` calls `Logger.set_level(args.log_level)` but `Logger` only had `set_debug()` and `_update_level()` — no public `set_level`.

## Test plan

- [ ] `openspace --log-level DEBUG` no longer crashes with `AttributeError`
- [ ] `openspace --log-level INFO` sets level correctly
- [ ] `openspace --log-level INVALID` raises `ValueError` with clear message

Closes #13

Made with [Cursor](https://cursor.com)