### PR TITLE
fix: use resolved tool_obj for fallback tool execution

### DIFF
--- a/openspace/llm/client.py
+++ b/openspace/llm/client.py
@@ -653,7 +653,7 @@ class LLMClient:
                 except:
                     pass
                 
-                if tool_name not in tool_map:
+                if tool_obj is None:
                     result = ToolResult(
                         status=ToolStatus.ERROR,
                         error=f"Tool '{tool_name}' not found"
@@ -661,7 +661,7 @@ class LLMClient:
                 else:
                     try:
                         result = await _execute_tool_call(
-                            tool=tool_map[tool_name],
+                            tool=tool_obj,
                             openai_tool_call={
                                 "id": tool_call.id,
                                 "type": "function",


### PR DESCRIPTION
## Summary

- Fix tool execution when LLM returns unqualified tool names (e.g. `read_file` vs `server__read_file` in the deduped map)
- The fallback scan correctly resolved `tool_obj` via `schema.name`, but the execution branch still checked `tool_name not in tool_map` and passed `tool_map[tool_name]`, causing all fallback-resolved tools to return "Tool not found"
- Change condition to `tool_obj is None` and pass `tool_obj` directly to `_execute_tool_call`

## Test plan

- [ ] MCP tool with namespaced key (e.g. `server__read_file`) executes when LLM calls it as `read_file`
- [ ] Direct key match (`tool_name in tool_map`) still works unchanged
- [ ] Tool-not-found error still triggers for genuinely unknown tool names

Closes #15

Made with [Cursor](https://cursor.com)