### PR TITLE
fix(security): harden zip extraction against path traversal

### DIFF
--- a/openspace/cloud/client.py
+++ b/openspace/cloud/client.py
@@ -401,6 +401,7 @@ class OpenSpaceClient:
     def _extract_zip(zip_data: bytes, target_dir: Path) -> List[str]:
         """Extract zip bytes to target directory with path traversal protection."""
         extracted: List[str] = []
+        resolved_target = target_dir.resolve()
         try:
             with zipfile.ZipFile(io.BytesIO(zip_data)) as zf:
                 for info in zf.infolist():
@@ -409,7 +410,9 @@ class OpenSpaceClient:
                     clean_name = Path(info.filename).as_posix()
                     if clean_name.startswith("..") or clean_name.startswith("/"):
                         continue
-                    target_path = target_dir / clean_name
+                    target_path = (target_dir / clean_name).resolve()
+                    if not target_path.is_relative_to(resolved_target):
+                        continue
                     target_path.parent.mkdir(parents=True, exist_ok=True)
                     target_path.write_bytes(zf.read(info))
                     extracted.append(clean_name)


### PR DESCRIPTION
## Summary

- Fix incomplete path traversal protection in `cloud/client.py` `_extract_zip()`
- Previous check only rejected filenames starting with `..` or `/`, missing entries like `subdir/../../../etc/passwd`
- Now resolve the final target path and verify it stays within the target directory via `Path.is_relative_to()`

## Test plan

- [ ] Normal skill zip extracts correctly
- [ ] Zip entry with `../` in middle of path is silently skipped
- [ ] Zip entry starting with `..` is still skipped
- [ ] Zip entry starting with `/` is still skipped

Closes #17

Made with [Cursor](https://cursor.com)