### PR TITLE
fix(security): stop leaking Python tracebacks to MCP clients

### DIFF
--- a/openspace/mcp_server.py
+++ b/openspace/mcp_server.py
@@ -22,7 +22,6 @@ import json
 import logging
 import os
 import sys
-import traceback
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -612,7 +611,7 @@ async def execute_task(
 
     except Exception as e:
         logger.error(f"execute_task failed: {e}", exc_info=True)
-        return _json_error(e, status="error", traceback=traceback.format_exc(limit=5))
+        return _json_error(e, status="error")
 
 
 @mcp.tool()
@@ -833,7 +832,7 @@ async def fix_skill(
 
     except Exception as e:
         logger.error(f"fix_skill failed: {e}", exc_info=True)
-        return _json_error(e, status="error", traceback=traceback.format_exc(limit=5))
+        return _json_error(e, status="error")
 
 
 @mcp.tool()
@@ -904,7 +903,7 @@ async def upload_skill(
 
     except Exception as e:
         logger.error(f"upload_skill failed: {e}", exc_info=True)
-        return _json_error(e, status="error", traceback=traceback.format_exc(limit=5))
+        return _json_error(e, status="error")
 
 def run_mcp_server() -> None:
     """Console-script entry point for ``openspace-mcp``."""


### PR DESCRIPTION
## Summary

- Remove `traceback=traceback.format_exc(limit=5)` from error responses returned to MCP clients in `execute_task`, `fix_skill`, and `upload_skill`
- Full tracebacks are already logged server-side via `logger.error(exc_info=True)` — no diagnostic information is lost
- Remove unused `import traceback`

## Motivation

Returning tracebacks to external clients exposes internal file paths, code structure, library versions, and potentially sensitive configuration details.

## Test plan

- [ ] Trigger an error in `execute_task` — verify client receives `{"error": "...", "status": "error"}` without `traceback` field
- [ ] Verify server logs still contain full traceback for debugging

Closes #19

Made with [Cursor](https://cursor.com)