### PR TITLE
fix: register_skill_dir returns existing SkillMeta for already-registered skills

### DIFF
--- a/openspace/skill_engine/registry.py
+++ b/openspace/skill_engine/registry.py
@@ -321,7 +321,7 @@ class SkillRegistry:
             meta = self._parse_skill(skill_dir.name, skill_dir, skill_file, content)
             if meta.skill_id in self._skills:
                 logger.debug(f"register_skill_dir: {meta.skill_id} already exists")
-                return None
+                return self._skills[meta.skill_id]
             self._skills[meta.skill_id] = meta
             self._content_cache[meta.skill_id] = content
             logger.info(f"Hot-registered skill: {meta.skill_id}")


### PR DESCRIPTION
## Summary

Fixes #29. `register_skill_dir()` returned `None` when a skill was already registered, causing `fix_skill()` to incorrectly report "Failed to register skill".

## Root Cause

In `registry.py` line 323-324, `register_skill_dir()` returns `None` for already-registered skills:

```python
if meta.skill_id in self._skills:
    return None  # ← callers interpret this as failure
```

But `fix_skill()` in `mcp_server.py` treats any `None` return as a registration failure:

```python
meta = registry.register_skill_dir(skill_path)
if not meta:
    return _json_error(f"Failed to register skill from {skill_dir}")
```

## Fix

Return the existing `SkillMeta` instead of `None` when the skill is already registered:

```python
if meta.skill_id in self._skills:
    return self._skills[meta.skill_id]  # ← return existing meta
```

This makes `register_skill_dir()` truly idempotent — callers get a valid `SkillMeta` regardless of whether the skill was newly registered or already present.

## Impact

- 1 file changed, 1 line modified
- `fix_skill` now works correctly on already-registered skills
- No breaking changes — callers that only check `if not meta:` still work correctly
- `add_skill()` (line 226) is intentionally left unchanged as it has different semantics (skip + warning)