### PR TITLE
fix: pin litellm to <1.82.7 to mitigate PYSEC-2026-2 supply-chain attack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 
 dependencies = [
-    "litellm>=1.70.0",
+    "litellm>=1.70.0,<1.82.7",  # pinned to avoid PYSEC-2026-2 supply-chain compromise (1.82.7/1.82.8 were malicious)
     "python-dotenv>=1.0.0",
     "openai>=1.0.0",
     "jsonschema>=4.25.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # OpenSpace core dependencies
-litellm>=1.70.0
+litellm>=1.70.0,<1.82.7  # pinned to avoid PYSEC-2026-2 supply-chain compromise (1.82.7/1.82.8 were malicious)
 python-dotenv>=1.0.0
 openai>=1.0.0
 jsonschema>=4.25.0


### PR DESCRIPTION
## Summary

Pins the `litellm` dependency to `>=1.70.0,<1.82.7` in both `pyproject.toml` and `requirements.txt` to protect users from the supply-chain attack described in #31.

## Background

On March 24, 2026, versions `1.82.7` and `1.82.8` of `litellm` were published to PyPI containing malicious code (PYSEC-2026-2). These versions exfiltrate credentials including SSH keys, cloud credentials, .env files, and API keys to an attacker-controlled domain. Version `1.82.8` is particularly dangerous as it activates on every Python startup via a `.pth` file — no explicit import needed.

Since OpenSpace reads LLM API keys from host agent configs at startup, users who had a vulnerable version installed were at elevated risk.

PyPI has since removed the malicious packages. This PR adds an upper bound to prevent `pip install` from pulling them back in case of a re-upload or similar future attack.

## Changes

- `pyproject.toml`: `litellm>=1.70.0` → `litellm>=1.70.0,<1.82.7`
- `requirements.txt`: `litellm>=1.70.0` → `litellm>=1.70.0,<1.82.7`

## Notes

This is a stopgap fix. As discussed in #31, replacing `litellm` with direct provider SDK calls is the preferable long-term solution. I'm happy to help with that migration as well.

## References

- Closes #31
- PYSEC-2026-2
- BerriAI/litellm#24521
