### PR TITLE
feat: add Hermes Agent as third supported host agent

### DIFF
--- a/openspace/cloud/client.py
+++ b/openspace/cloud/client.py
@@ -313,6 +313,11 @@ class OpenSpaceClient:
         if not name:
             raise CloudError("SKILL.md frontmatter missing 'name' field")
 
+        # Auto-extract tags from frontmatter if not explicitly provided
+        if tags is None:
+            from openspace.skill_engine.skill_utils import extract_tags
+            tags = extract_tags(fm)
+
         parents = parent_skill_ids or []
         self._validate_origin_parents(origin, parents)
 

--- a/openspace/host_detection/__init__.py
+++ b/openspace/host_detection/__init__.py
@@ -16,6 +16,7 @@ Supported host agents:
 
   - **nanobot** — ``~/.nanobot/config.json``  (``tools.mcpServers.openspace.env``)
   - **openclaw** — ``~/.openclaw/openclaw.json``  (``skills.entries.openspace.env``)
+  - **hermes** — ``~/.hermes/config.yaml``  (``mcp_servers.openspace.env``)
 """
 
 import logging
@@ -37,6 +38,12 @@ from openspace.host_detection.openclaw import (
     read_openclaw_skill_env,
     try_read_openclaw_config,
 )
+from openspace.host_detection.hermes import (
+    get_hermes_openai_api_key as _hermes_get_openai_api_key,
+    is_hermes_host,
+    read_hermes_mcp_env,
+    try_read_hermes_config,
+)
 
 logger = logging.getLogger("openspace.host_detection")
 
@@ -45,13 +52,26 @@ def read_host_mcp_env() -> Dict[str, str]:
     """Read the OpenSpace env block from the current host agent config.
 
     Resolution order:
+      0. ``OPENSPACE_HOST`` env var — if set, skip auto-detection
       1. nanobot — ``tools.mcpServers.openspace.env``
       2. openclaw — ``skills.entries.openspace.env``
-      3. Empty dict (no host detected)
+      3. hermes — ``mcp_servers.openspace.env``
+      4. Empty dict (no host detected)
 
     Callers (e.g. ``cloud.auth``) use this single entry point and never
     need to know which host agent is active.
     """
+    import os
+    explicit_host = os.environ.get("OPENSPACE_HOST", "").strip().lower()
+    if explicit_host:
+        if explicit_host == "nanobot":
+            return read_nanobot_mcp_env()
+        if explicit_host == "openclaw":
+            return read_openclaw_skill_env("openspace")
+        if explicit_host == "hermes":
+            return read_hermes_mcp_env("openspace")
+        logger.warning("Unknown OPENSPACE_HOST=%r, falling back to auto-detection", explicit_host)
+
     # Try nanobot first (most common deployment)
     env = read_nanobot_mcp_env()
     if env:
@@ -63,6 +83,12 @@ def read_host_mcp_env() -> Dict[str, str]:
         logger.debug("read_host_mcp_env: resolved from OpenClaw config")
         return env
 
+    # Try hermes
+    env = read_hermes_mcp_env("openspace")
+    if env:
+        logger.debug("read_host_mcp_env: resolved from Hermes config")
+        return env
+
     return {}
 
 
@@ -70,16 +96,32 @@ def get_openai_api_key() -> Optional[str]:
     """Get OpenAI API key for embedding generation (multi-host).
 
     Resolution:
+      0. ``OPENSPACE_HOST`` env var — if set, try only that host
       1. ``OPENAI_API_KEY`` env var  (checked inside nanobot reader)
       2. nanobot config ``providers.openai.apiKey``
       3. openclaw config ``skills.entries.openspace.env.OPENAI_API_KEY``
-      4. None
+      4. hermes config / env
+      5. None
     """
-    # nanobot reader already checks OPENAI_API_KEY env var first
+    import os
+    explicit_host = os.environ.get("OPENSPACE_HOST", "").strip().lower()
+    if explicit_host:
+        if explicit_host == "nanobot":
+            return _nanobot_get_openai_api_key()
+        if explicit_host == "openclaw":
+            return _openclaw_get_openai_api_key()
+        if explicit_host == "hermes":
+            return _hermes_get_openai_api_key()
+        logger.warning("Unknown OPENSPACE_HOST=%r, falling back to auto-detection", explicit_host)
+
+    # Auto-detection chain
     key = _nanobot_get_openai_api_key()
     if key:
         return key
-    return _openclaw_get_openai_api_key()
+    key = _openclaw_get_openai_api_key()
+    if key:
+        return key
+    return _hermes_get_openai_api_key()
 
 
 __all__ = [
@@ -93,4 +135,7 @@ __all__ = [
     "is_openclaw_host",
     "read_openclaw_skill_env",
     "try_read_openclaw_config",
+    "is_hermes_host",
+    "read_hermes_mcp_env",
+    "try_read_hermes_config",
 ]

--- a/openspace/host_detection/hermes.py
+++ b/openspace/host_detection/hermes.py
@@ -1,0 +1,165 @@
+"""Hermes Agent host-agent config reader.
+
+Reads ``~/.hermes/config.yaml`` to auto-detect:
+  - LLM provider credentials (``model.api_key``, ``model.base_url``, ``model.provider``)
+  - MCP server env block for the ``openspace`` server (``mcp_servers.openspace.env``)
+  - Default model and provider settings
+
+Config path resolution:
+  1. ``HERMES_CONFIG_PATH`` env var
+  2. ``HERMES_HOME/config.yaml``
+  3. ``~/.hermes/config.yaml`` (default)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("openspace.host_detection")
+
+# Provider name → Hermes config key mapping for credential extraction.
+# Hermes stores API keys in env vars (`.env` file), not in config.yaml,
+# so we map provider names to the env var names Hermes uses.
+_HERMES_PROVIDER_ENV_KEYS: Dict[str, tuple[str, ...]] = {
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    "nous": ("NOUS_API_KEY",),
+    "zai": ("GLM_API_KEY",),
+    "kimi-coding": ("KIMI_API_KEY",),
+    "moonshot": ("MOONSHOT_API_KEY",),
+    "minimax": ("MINIMAX_API_KEY",),
+    "minimax-cn": ("MINIMAX_CN_API_KEY",),
+    "groq": ("GROQ_API_KEY",),
+    "huggingface": ("HF_TOKEN",),
+    "copilot": ("GITHUB_TOKEN",),
+}
+
+
+def _resolve_hermes_home() -> Path:
+    """Resolve the Hermes home directory."""
+    explicit = os.environ.get("HERMES_HOME", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / ".hermes"
+
+
+def _resolve_config_path() -> Path:
+    """Resolve the Hermes config file path."""
+    explicit = os.environ.get("HERMES_CONFIG_PATH", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return _resolve_hermes_home() / "config.yaml"
+
+
+def _load_hermes_config() -> Optional[Dict[str, Any]]:
+    """Load and parse Hermes config.yaml. Returns None on failure."""
+    config_path = _resolve_config_path()
+    if not config_path.is_file():
+        return None
+    try:
+        import yaml
+    except ImportError:
+        logger.debug("PyYAML not installed, cannot read Hermes config")
+        return None
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data if isinstance(data, dict) else None
+    except Exception as e:
+        logger.warning("Failed to read Hermes config %s: %s", config_path, e)
+        return None
+
+
+def is_hermes_host() -> bool:
+    """Check if Hermes Agent is installed (config file exists)."""
+    return _resolve_config_path().is_file()
+
+
+def read_hermes_mcp_env(server_name: str = "openspace") -> Dict[str, str]:
+    """Read the env block from a Hermes MCP server config entry.
+
+    Looks for ``mcp_servers.<server_name>.env`` in config.yaml.
+    Returns an empty dict if not found.
+    """
+    config = _load_hermes_config()
+    if not config:
+        return {}
+    mcp_servers = config.get("mcp_servers", {})
+    if not isinstance(mcp_servers, dict):
+        return {}
+    server = mcp_servers.get(server_name, {})
+    if not isinstance(server, dict):
+        return {}
+    env = server.get("env", {})
+    return dict(env) if isinstance(env, dict) else {}
+
+
+def try_read_hermes_config(model: str = "") -> Optional[Dict[str, Any]]:
+    """Try to read LLM credentials from Hermes config.
+
+    Extracts provider, model, api_key, and api_base from the Hermes
+    ``model`` config section and maps them to litellm kwargs.
+
+    Returns None if Hermes is not installed or config is unreadable.
+    """
+    config = _load_hermes_config()
+    if not config:
+        return None
+
+    model_cfg = config.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return None
+
+    result: Dict[str, Any] = {}
+
+    # Extract provider
+    provider = model_cfg.get("provider", "auto")
+
+    # Extract model name
+    hermes_model = model_cfg.get("default") or model_cfg.get("model", "")
+    if hermes_model and not model:
+        result["_model"] = str(hermes_model)
+
+    # Extract API key — check config first, then env vars for the provider
+    api_key = model_cfg.get("api_key", "")
+    if not api_key and provider in _HERMES_PROVIDER_ENV_KEYS:
+        for env_name in _HERMES_PROVIDER_ENV_KEYS[provider]:
+            api_key = os.environ.get(env_name, "").strip()
+            if api_key:
+                break
+
+    if api_key:
+        result["api_key"] = api_key
+
+    # Extract API base URL
+    base_url = model_cfg.get("base_url", "")
+    if base_url:
+        result["api_base"] = str(base_url)
+
+    # Map provider to forced_provider for gateway prefix prepending
+    _GATEWAY_PROVIDERS = {"openrouter", "aihubmix", "siliconflow"}
+    if provider in _GATEWAY_PROVIDERS:
+        result["_forced_provider"] = provider
+
+    if result:
+        logger.info("Hermes config resolved: provider=%s, model=%s", provider, hermes_model)
+        return result
+
+    return None
+
+
+def get_hermes_openai_api_key() -> Optional[str]:
+    """Get OpenAI API key from Hermes config or env for embedding generation."""
+    # Check env first (Hermes stores keys in .env)
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if key:
+        return key
+
+    # Try reading from Hermes MCP server env block
+    env = read_hermes_mcp_env("openspace")
+    return env.get("OPENAI_API_KEY") or None

--- a/openspace/host_detection/resolver.py
+++ b/openspace/host_detection/resolver.py
@@ -147,8 +147,12 @@ def build_llm_kwargs(model: str) -> tuple[str, Dict[str, Any]]:
 
     Tier 3 — Host-agent config file fallback (only when Tier 1+2 absent)::
 
+        If ``OPENSPACE_HOST`` is set, only that host is tried.
+        Otherwise auto-detection chain:
+
         nanobot  → ``~/.nanobot/config.json``
         openclaw → ``~/.openclaw/openclaw.json``
+        hermes   → ``~/.hermes/config.yaml``
 
     Returns:
         ``(resolved_model, llm_kwargs_dict)``
@@ -171,15 +175,45 @@ def build_llm_kwargs(model: str) -> tuple[str, Dict[str, Any]]:
     host_config = None
     host_source = None
     if not has_explicit_llm_override and not provider_native_env_used:
-        from openspace.host_detection.nanobot import try_read_nanobot_config
-        host_config = try_read_nanobot_config(model)
-        if host_config:
-            host_source = "nanobot config"
-        else:
-            from openspace.host_detection.openclaw import try_read_openclaw_config
-            host_config = try_read_openclaw_config(model)
+        explicit_host = os.environ.get("OPENSPACE_HOST", "").strip().lower()
+
+        if explicit_host:
+            # Explicit host selection — skip auto-detection chain
+            if explicit_host == "nanobot":
+                from openspace.host_detection.nanobot import try_read_nanobot_config
+                host_config = try_read_nanobot_config(model)
+                if host_config:
+                    host_source = "nanobot config"
+            elif explicit_host == "openclaw":
+                from openspace.host_detection.openclaw import try_read_openclaw_config
+                host_config = try_read_openclaw_config(model)
+                if host_config:
+                    host_source = "openclaw config"
+            elif explicit_host == "hermes":
+                from openspace.host_detection.hermes import try_read_hermes_config
+                host_config = try_read_hermes_config(model)
+                if host_config:
+                    host_source = "hermes config"
+            else:
+                logger.warning("Unknown OPENSPACE_HOST=%r, falling back to auto-detection", explicit_host)
+                explicit_host = ""  # fall through to auto-detection
+
+        if not explicit_host:
+            # Auto-detection chain: nanobot → openclaw → hermes
+            from openspace.host_detection.nanobot import try_read_nanobot_config
+            host_config = try_read_nanobot_config(model)
             if host_config:
-                host_source = "openclaw config"
+                host_source = "nanobot config"
+            else:
+                from openspace.host_detection.openclaw import try_read_openclaw_config
+                host_config = try_read_openclaw_config(model)
+                if host_config:
+                    host_source = "openclaw config"
+                else:
+                    from openspace.host_detection.hermes import try_read_hermes_config
+                    host_config = try_read_hermes_config(model)
+                    if host_config:
+                        host_source = "hermes config"
 
     if host_config:
         host_model = host_config.pop("_model", None)

--- a/openspace/host_skills/README.md
+++ b/openspace/host_skills/README.md
@@ -19,6 +19,7 @@ The endpoint is common; the **host config syntax is not**. nanobot uses `tools.m
 |------------|-------------|
 | **[nanobot](https://github.com/HKUDS/nanobot)** | [Setup for nanobot](#setup-for-nanobot) |
 | **[openclaw](https://github.com/openclaw/openclaw)** | [Setup for openclaw](#setup-for-openclaw) |
+| **[Hermes Agent](https://github.com/NousResearch/hermes-agent)** | [Setup for Hermes Agent](#setup-for-hermes-agent) |
 | **Other agents** | Follow the [generic setup](../../README.md#-path-a-empower-your-agent-with-openspace) in the main README |
 
 ---
@@ -127,6 +128,72 @@ openclaw mcp set openspace '{"url":"http://127.0.0.1:8080","connectionTimeoutMs"
 
 ---
 
+## Setup for Hermes Agent
+
+Hermes Agent connects to OpenSpace via its built-in MCP client. OpenSpace auto-detects Hermes credentials from `~/.hermes/config.yaml`.
+
+### 1. Install OpenSpace
+
+```bash
+pip install openspace
+```
+
+### 2. Option A: stdio (simplest)
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  openspace:
+    command: "openspace-mcp"
+    env:
+      OPENSPACE_API_KEY: "sk-xxx"  # optional, enables cloud skill search/upload
+    timeout: 600  # important: execute_task can take minutes
+```
+
+> [!TIP]
+> LLM credentials are auto-detected from Hermes's `model.*` config and provider env vars — no need to set `OPENSPACE_LLM_API_KEY`.
+
+### 3. Option B: remote HTTP transport
+
+Start OpenSpace as a standalone server:
+
+```bash
+openspace-mcp --transport sse --host 127.0.0.1 --port 8080
+```
+
+Then in `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  openspace:
+    url: "http://127.0.0.1:8080/sse"
+    timeout: 600
+```
+
+### 4. Verify
+
+After configuring, Hermes will auto-discover 4 tools (prefixed as `mcp_openspace_*`):
+
+```
+hermes tools  # should show mcp_openspace_execute_task, etc.
+```
+
+### 5. Host skills (optional)
+
+Copy the host skills to Hermes's skill directory for better delegation decisions:
+
+```bash
+cp -r host_skills/delegate-task/ ~/.hermes/skills/
+cp -r host_skills/skill-discovery/ ~/.hermes/skills/
+```
+
+### Skill format compatibility
+
+Hermes skills use the [agentskills.io](https://agentskills.io) standard with optional fields like `version`, `author`, `tags`, `platforms`, and `metadata`. OpenSpace now supports these fields — skills authored in Hermes work in OpenSpace and vice versa.
+
+---
+
 ## Environment Variables (Agent-Specific)
 
 The three env vars in each agent's setup above are the most important. For the **full env var list**, config files reference, and advanced settings, see the [Configuration Guide](../../README.md#configuration-guide) in the main README.
@@ -150,7 +217,7 @@ All tools default to `"all"` (local + cloud) and **automatically fall back** to 
 ## How It Works
 
 ```
-Your Agent (nanobot / openclaw / ...)
+Your Agent (nanobot / openclaw / Hermes Agent / ...)
   │
   │  MCP protocol (stdio | HTTP/SSE | streamable-http)
   ▼

--- a/openspace/host_skills/delegate-task/SKILL.md
+++ b/openspace/host_skills/delegate-task/SKILL.md
@@ -130,3 +130,19 @@ upload_skill(
 - If `execute_task` times out, first check the host's MCP timeout settings. Changing from `stdio` to HTTP (`sse` or `streamable-http`) does not remove host-side per-call time limits.
 - `upload_skill` requires a cloud API key; if it fails, the evolved skill is still saved locally.
 - After every OpenSpace call, **tell the user** what happened: task result, any evolved skills, and your upload decision.
+
+## Host-Specific Tool Names
+
+Some host agents prefix MCP tool names. Use the correct name for your host:
+
+| Host Agent | Tool Name Format | Example |
+|------------|-----------------|---------|
+| nanobot / openclaw | `execute_task` | `execute_task(task="...")` |
+| Claude Code | `mcp__openspace__execute_task` | `mcp__openspace__execute_task(task="...")` |
+| Hermes Agent | `mcp_openspace_execute_task` | `mcp_openspace_execute_task(task="...")` |
+
+Hermes Agent uses `mcp_<server>_<tool>` naming. All 4 tools are available as:
+- `mcp_openspace_execute_task`
+- `mcp_openspace_search_skills`
+- `mcp_openspace_fix_skill`
+- `mcp_openspace_upload_skill`

--- a/openspace/skill_engine/registry.py
+++ b/openspace/skill_engine/registry.py
@@ -1,7 +1,9 @@
 """SkillRegistry — discover, load, match, and inject skills.
 
 Skills follow the official SKILL.md format:
-  - YAML frontmatter with only ``name`` and ``description``
+  - YAML frontmatter with ``name`` and ``description`` (required)
+  - Optional agentskills.io fields: ``version``, ``author``, ``license``,
+    ``tags``, ``platforms``, ``metadata``
   - Markdown body with instructions (loaded only after selection)
 
 Skills are discovered from user-configured directories and matched to
@@ -29,7 +31,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from openspace.utils.logging import Logger
-from .skill_utils import parse_frontmatter, strip_frontmatter, check_skill_safety, is_skill_safe
+from .skill_utils import parse_frontmatter, strip_frontmatter, check_skill_safety, is_skill_safe, extract_tags
 from .skill_ranker import SkillRanker, SkillCandidate, PREFILTER_THRESHOLD
 
 if TYPE_CHECKING:
@@ -91,12 +93,27 @@ class SkillMeta:
     ``skill_id`` is the globally unique identifier used throughout the
     system — LLM prompts, database, evolution, and selection all
     reference this field.
+
+    ``tags`` is first-class because it directly affects skill ranking
+    (BM25 + embedding).  All other optional agentskills.io fields
+    (version, author, license, platforms, etc.) are stored in
+    ``metadata`` and accessed on demand.
     """
 
     skill_id: str          # Unique — persisted in .skill_id sidecar
     name: str              # Human-readable name (from frontmatter or dirname)
     description: str
     path: Path             # Absolute path to SKILL.md
+
+    # Tags affect ranking — kept as first-class field
+    tags: Optional[List[str]] = None
+
+    # All other optional fields (version, author, license, platforms, etc.)
+    metadata: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self) -> None:
+        if self.metadata is None:
+            self.metadata = {}
 
 
 class SkillRegistry:
@@ -528,6 +545,7 @@ class SkillRegistry:
                 name=s.name,
                 description=s.description,
                 body=body,
+                tags=s.tags,
             ))
 
         ranked = self.ranker.hybrid_rank(task, candidates, top_k=prefilter_top_k)
@@ -642,20 +660,32 @@ class SkillRegistry:
     ) -> SkillMeta:
         """Parse a SKILL.md file into a SkillMeta.
 
-        Only ``name`` and ``description`` are read from frontmatter
-        (per the official skill format).  ``skill_id`` is read from
-        the ``.skill_id`` sidecar (created if absent).
+        Required fields: ``name`` and ``description``.
+        Optional agentskills.io fields are stored in ``metadata``.
+        ``skill_id`` is read from the ``.skill_id`` sidecar (created if absent).
         """
         frontmatter = parse_frontmatter(content)
         name = frontmatter.get("name", dir_name)
         description = frontmatter.get("description", name)
         skill_id = _read_or_create_skill_id(name, skill_dir)
 
+        # Extract tags via unified helper
+        tags = extract_tags(frontmatter)
+
+        # Collect optional agentskills.io fields into metadata
+        meta_fields: Dict[str, Any] = {}
+        for key in ("version", "author", "license", "platforms", "metadata"):
+            val = frontmatter.get(key)
+            if val is not None:
+                meta_fields[key] = val
+
         return SkillMeta(
             skill_id=skill_id,
             name=name,
             description=description,
             path=skill_file,
+            tags=tags,
+            metadata=meta_fields,
         )
 
     # Frontmatter parsing is delegated to skill_utils (single source of truth).

--- a/openspace/skill_engine/skill_ranker.py
+++ b/openspace/skill_engine/skill_ranker.py
@@ -55,6 +55,7 @@ class SkillCandidate:
     description: str
     body: str = ""             # SKILL.md body (frontmatter stripped)
     source: str = "local"      # "local" | "cloud"
+    tags: Optional[List[str]] = None  # agentskills.io tags for ranking boost
     # Internal ranking fields
     embedding: Optional[List[float]] = None
     embedding_text: str = ""   # text used to compute embedding
@@ -203,10 +204,12 @@ class SkillRanker:
         except ImportError:
             BM25Okapi = None
 
-        # Build corpus: name + description + truncated body for richer matching
+        # Build corpus: name + description + tags + truncated body for richer matching
         corpus_tokens = []
         for c in candidates:
             text = f"{c.name} {c.description}"
+            if c.tags:
+                text += f" {' '.join(c.tags)}"
             if c.body:
                 text += f" {c.body[:2000]}"  # include body for BM25 but cap length
             corpus_tokens.append(self._tokenize(text))

--- a/openspace/skill_engine/skill_utils.py
+++ b/openspace/skill_engine/skill_utils.py
@@ -301,6 +301,49 @@ def validate_skill_dir(skill_dir: Path) -> Optional[str]:
     return None
 
 
+def _parse_tag_value(raw: Any) -> Optional[List[str]]:
+    """Coerce a raw tag value into a list of strings.
+
+    Handles:
+      - Python list (from full YAML parser): ``["a", "b"]`` → as-is
+      - Inline YAML list string: ``"[a, b, c]"`` → split + strip
+      - Comma-separated string: ``"a, b, c"`` → split + strip
+      - Empty / None → None
+    """
+    if isinstance(raw, list):
+        return [str(t).strip() for t in raw if str(t).strip()]
+    if isinstance(raw, str) and raw.strip():
+        s = raw.strip()
+        # Strip surrounding brackets: "[a, b]" → "a, b"
+        if s.startswith("[") and s.endswith("]"):
+            s = s[1:-1]
+        tags = [t.strip() for t in s.split(",") if t.strip()]
+        return tags if tags else None
+    return None
+
+
+def extract_tags(frontmatter: Dict[str, Any]) -> Optional[List[str]]:
+    """Extract tags from SKILL.md frontmatter, supporting multiple formats.
+
+    Resolution order:
+      1. ``tags`` (top-level — list or comma-separated string)
+      2. ``metadata.hermes.tags`` (Hermes/agentskills.io nested format)
+
+    Returns a list of tag strings, or None if no tags found.
+    """
+    raw_tags = frontmatter.get("tags")
+    result = _parse_tag_value(raw_tags)
+    if result:
+        return result
+    # Fallback: Hermes-style metadata.hermes.tags
+    meta = frontmatter.get("metadata", {})
+    if isinstance(meta, dict):
+        hermes_block = meta.get("hermes", {})
+        if isinstance(hermes_block, dict):
+            return _parse_tag_value(hermes_block.get("tags"))
+    return None
+
+
 def truncate(text: str, max_chars: int) -> str:
     """Truncate *text* to *max_chars* with an ellipsis marker."""
     if len(text) <= max_chars:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pydantic>=2.12.0",
     "aiohttp>=3.10.0",
     "requests>=2.32.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Add Hermes Agent as third supported host agent (nanobot → openclaw → hermes fallback chain)
- Add `OPENSPACE_HOST` env var for explicit host selection, skipping auto-detection
- Unify tag extraction into `extract_tags()` in `skill_utils.py`, supporting comma-separated strings, inline YAML lists, and Python lists
- Simplify `SkillMeta` — `tags` as first-class field, other agentskills.io fields in `metadata: Optional[Dict[str, Any]]`
- Enhance BM25 skill ranking with tag-aware corpus
- Add `pyyaml>=6.0` dependency for Hermes YAML config parsing

## Files changed (10 files, +428 lines)

- `openspace/host_detection/hermes.py` — new: Hermes config reader (`yaml.safe_load`)
- `openspace/host_detection/__init__.py` — `OPENSPACE_HOST` support + Hermes in detection chain
- `openspace/host_detection/resolver.py` — `OPENSPACE_HOST` in Tier 3 LLM credential resolution
- `openspace/skill_engine/skill_utils.py` — `extract_tags()` + `_parse_tag_value()` helpers
- `openspace/skill_engine/registry.py` — simplified `SkillMeta`, uses `extract_tags()`
- `openspace/skill_engine/skill_ranker.py` — tags in BM25 corpus
- `openspace/cloud/client.py` — uses `extract_tags()`, `if tags is None` fix
- `openspace/host_skills/README.md` — Hermes setup documentation
- `openspace/host_skills/delegate-task/SKILL.md` — Hermes in supported hosts
- `pyproject.toml` — `pyyaml>=6.0` dependency

## Test plan

- [ ] Verify Hermes config detection with `~/.hermes/config.yaml` present/absent
- [ ] Verify `OPENSPACE_HOST=hermes` skips nanobot/openclaw detection
- [ ] Verify `extract_tags()` handles: Python list, `"[a, b]"` string, `"a, b"` string, None
- [ ] Verify `get_openai_api_key()` respects `OPENSPACE_HOST`
- [ ] Verify skill ranking includes tags in BM25 corpus