### PR TITLE
fix: resolve macOS dependency conflict in extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Desktop.ini
 .vscode/
 .idea/
 .pytest_cache/
+.venv/
 
 # Distribution / packaging
 dist/

--- a/openspace/local_server/README.md
+++ b/openspace/local_server/README.md
@@ -37,8 +37,14 @@ Set `"mode": "server"` in `openspace/config/config_grounding.json`:
 <summary><b>macOS</b></summary>
 
 ```bash
-pip install pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz atomacos
+pip install pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz
 ```
+
+`atomacos` is not included in the default macOS dependency set right now because
+its published releases require `pyautogui<0.9.42`, which conflicts with
+OpenSpace's `pyautogui>=0.9.54`. OpenSpace will still run without it, but the
+macOS accessibility-tree features will stay unavailable until that upstream
+constraint is resolved.
 
 **Permissions required** (macOS will prompt automatically on first run):
 - **Accessibility** (for GUI control)

--- a/openspace/local_server/README.md
+++ b/openspace/local_server/README.md
@@ -40,11 +40,7 @@ Set `"mode": "server"` in `openspace/config/config_grounding.json`:
 pip install pyobjc-core pyobjc-framework-cocoa pyobjc-framework-quartz
 ```
 
-`atomacos` is not included in the default macOS dependency set right now because
-its published releases require `pyautogui<0.9.42`, which conflicts with
-OpenSpace's `pyautogui>=0.9.54`. OpenSpace will still run without it, but the
-macOS accessibility-tree features will stay unavailable until that upstream
-constraint is resolved.
+> **Note:** `atomacos` is excluded because it requires `pyautogui<0.9.42` (appears unmaintained). Accessibility-tree features are currently unavailable.
 
 **Permissions required** (macOS will prompt automatically on first run):
 - **Accessibility** (for GUI control)

--- a/openspace/local_server/platform_adapters/macos_adapter.py
+++ b/openspace/local_server/platform_adapters/macos_adapter.py
@@ -20,7 +20,8 @@ class MacOSAdapter:
         global _warning_shown
         if not MACOS_LIBS_AVAILABLE and not _warning_shown:
             logger.warning("macOS libraries are not fully installed, some features may not be available")
-            logger.info("To install missing libraries, run: pip install pyobjc-framework-Cocoa atomacos")
+            logger.info("To install missing libraries, run: pip install pyobjc-core pyobjc-framework-Cocoa pyobjc-framework-quartz")
+            logger.info("Note: atomacos is currently optional because its published versions conflict with pyautogui>=0.9.54")
             _warning_shown = True
         self.available = MACOS_LIBS_AVAILABLE
     

--- a/openspace/local_server/platform_adapters/macos_adapter.py
+++ b/openspace/local_server/platform_adapters/macos_adapter.py
@@ -5,10 +5,15 @@ from openspace.utils.logging import Logger
 
 try:
     import AppKit
-    import atomacos
     MACOS_LIBS_AVAILABLE = True
 except ImportError:
     MACOS_LIBS_AVAILABLE = False
+
+try:
+    import atomacos
+    ATOMACOS_AVAILABLE = True
+except ImportError:
+    ATOMACOS_AVAILABLE = False
 
 logger = Logger.get_logger(__name__)
 
@@ -21,8 +26,9 @@ class MacOSAdapter:
         if not MACOS_LIBS_AVAILABLE and not _warning_shown:
             logger.warning("macOS libraries are not fully installed, some features may not be available")
             logger.info("To install missing libraries, run: pip install pyobjc-core pyobjc-framework-Cocoa pyobjc-framework-quartz")
-            logger.info("Note: atomacos is currently optional because its published versions conflict with pyautogui>=0.9.54")
             _warning_shown = True
+        if not ATOMACOS_AVAILABLE:
+            logger.debug("atomacos not installed; accessibility-tree features unavailable (conflicts with pyautogui>=0.9.54)")
         self.available = MACOS_LIBS_AVAILABLE
     
     def capture_screenshot_with_cursor(self, output_path: str) -> bool:
@@ -164,6 +170,8 @@ class MacOSAdapter:
         """
         if not MACOS_LIBS_AVAILABLE:
             return {'error': 'macOS accessibility libraries not available'}
+        if not ATOMACOS_AVAILABLE:
+            return {'error': 'atomacos is not installed; accessibility-tree features require it'}
         
         try:
             # Get frontmost application
@@ -178,7 +186,6 @@ class MacOSAdapter:
             
             logger.info(f"Getting accessibility tree: {app_name} ({bundle_id})")
             
-            # Use atomacos to get application reference
             try:
                 if bundle_id:
                     app_ref = atomacos.getAppRefByBundleId(bundle_id)

--- a/openspace/local_server/requirements.txt
+++ b/openspace/local_server/requirements.txt
@@ -8,8 +8,7 @@ requests>=2.32.0
 # pyobjc-core>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-cocoa>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-quartz>=12.0; sys_platform == 'darwin'
-# atomacos is intentionally excluded for now: atomacos 3.2+/3.3 requires
-# pyautogui<0.9.42, which conflicts with OpenSpace's pyautogui>=0.9.54.
+# atomacos excluded: requires pyautogui<0.9.42, conflicts with >=0.9.54
 
 # # Linux-specific dependencies (local server)
 # python-xlib>=0.33; sys_platform == 'linux'

--- a/openspace/local_server/requirements.txt
+++ b/openspace/local_server/requirements.txt
@@ -8,7 +8,8 @@ requests>=2.32.0
 # pyobjc-core>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-cocoa>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-quartz>=12.0; sys_platform == 'darwin'
-# atomacos>=3.2.0; sys_platform == 'darwin'
+# atomacos is intentionally excluded for now: atomacos 3.2+/3.3 requires
+# pyautogui<0.9.42, which conflicts with OpenSpace's pyautogui>=0.9.54.
 
 # # Linux-specific dependencies (local server)
 # python-xlib>=0.33; sys_platform == 'linux'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ macos = [
     "pyobjc-core>=12.0",
     "pyobjc-framework-cocoa>=12.0",
     "pyobjc-framework-quartz>=12.0",
-    "atomacos>=3.2.0",
 ]
 
 linux = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ requests>=2.32.0
 # pyobjc-core>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-cocoa>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-quartz>=12.0; sys_platform == 'darwin'
-# atomacos>=3.2.0; sys_platform == 'darwin'
+# atomacos is intentionally excluded for now: atomacos 3.2+/3.3 requires
+# pyautogui<0.9.42, which conflicts with OpenSpace's pyautogui>=0.9.54.
 
 # # Linux-specific dependencies (local server)
 # python-xlib>=0.33; sys_platform == 'linux'

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,7 @@ requests>=2.32.0
 # pyobjc-core>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-cocoa>=12.0; sys_platform == 'darwin'
 # pyobjc-framework-quartz>=12.0; sys_platform == 'darwin'
-# atomacos is intentionally excluded for now: atomacos 3.2+/3.3 requires
-# pyautogui<0.9.42, which conflicts with OpenSpace's pyautogui>=0.9.54.
+# atomacos excluded: requires pyautogui<0.9.42, conflicts with >=0.9.54
 
 # # Linux-specific dependencies (local server)
 # python-xlib>=0.33; sys_platform == 'linux'


### PR DESCRIPTION
## Summary
- remove `atomacos` from the default `macos` extra because its published releases require `pyautogui<0.9.42`
- keep the macOS install path aligned with the current `pyautogui>=0.9.54` requirement
- ignore local `.venv/` directories to avoid accidentally committing local environments

## Validation
- rebuilt `OpenSpace/.venv`
- ran `pip install -e '.[macos]'` successfully on macOS
- verified `pyautogui` and `AppKit` import successfully after the dependency change

## Notes
- `atomacos` remains optional for now, and macOS accessibility-tree features stay unavailable until the upstream version constraint is resolved.