### PR TITLE
feat(llm): add stream mode support for OpenAI-compatible proxies

### DIFF
--- a/openspace/llm/client.py
+++ b/openspace/llm/client.py
@@ -548,14 +548,27 @@ class LLMClient:
         - Total max time: timeout * max_retries + sum(retry_delays)
         """
         last_exception = None
+        use_stream = completion_kwargs.pop("stream", False)
+        if use_stream:
+            completion_kwargs["stream_options"] = {"include_usage": True}
         
         for attempt in range(self.max_retries):
             try:
-                # Add timeout to the completion call
-                response = await asyncio.wait_for(
-                    litellm.acompletion(**completion_kwargs),
-                    timeout=self.timeout
-                )
+                if use_stream:
+                    chunks = []
+                    async for chunk in await litellm.acompletion(stream=True, **completion_kwargs):
+                        chunks.append(chunk)
+                    if not chunks:
+                        raise ValueError("Stream returned no chunks")
+                    response = await asyncio.wait_for(
+                        asyncio.to_thread(litellm.stream_chunk_builder, chunks, completion_kwargs.get("messages", [])),
+                        timeout=self.timeout,
+                    )
+                else:
+                    response = await asyncio.wait_for(
+                        litellm.acompletion(**completion_kwargs),
+                        timeout=self.timeout
+                    )
                 return response
             except asyncio.TimeoutError:
                 self._logger.error(


### PR DESCRIPTION
## Summary

Some OpenAI-compatible proxies (e.g. jarodfund.xyz) return empty `message.content` in non-streaming mode, causing `execute_task` to fail with 0 iterations and empty responses. This PR adds stream mode support to the LLM client so these proxies work correctly.

## Changes

- Added `stream` parameter handling in `_call_with_retry`: when `stream=True` is passed via `OPENSPACE_LLM_CONFIG`, the client uses `litellm.acompletion(stream=True)` and reassembles chunks with `litellm.stream_chunk_builder`
- Non-streaming mode remains the default — zero behavior change for existing users

## Usage

Add to `openspace/.env`:
```
OPENSPACE_LLM_CONFIG={"stream": true}
```

Or pass `stream=True` via `litellm_kwargs` when constructing `LLMClient`.

## Testing

Tested via MCP stdio with `execute_task` against a proxy that only returns content in streaming mode. Task completed successfully with correct tool calls and responses.