### PR TITLE
fix: Windows compatibility for _is_pid_alive in communication gateway

### DIFF
--- a/openspace/communication/gateway_runtime.py
+++ b/openspace/communication/gateway_runtime.py
@@ -36,7 +36,23 @@ def _is_pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
     try:
-        os.kill(pid, 0)
+        if sys.platform == "win32":
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            STILL_ACTIVE = 259
+            handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+            if not handle:
+                return False
+            try:
+                exit_code = ctypes.c_ulong()
+                if kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                    return exit_code.value == STILL_ACTIVE
+                return False
+            finally:
+                kernel32.CloseHandle(handle)
+        else:
+            os.kill(pid, 0)
     except ProcessLookupError:
         return False
     except PermissionError:


### PR DESCRIPTION
## Problem

The OpenSpace communication gateway fails to start on Windows due to platform-specific code in \_is_pid_alive\ function.

Fixes #90

## Changes

- Use Windows API (OpenProcess/GetExitCodeProcess) on Windows platform
- Fall back to \os.kill(pid, 0)\ on Unix-like systems

## Root Cause

The \os.kill(pid, 0)\ approach fails on Windows with \OSError: [WinError 87]\, preventing the communication gateway from starting on Windows.

## Testing

Tested on:
- Windows 10 with Python 3.12.0
- Communication gateway starts successfully after this fix