### PR TITLE
fix(deps): relax litellm security pin window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 
 dependencies = [
-    "litellm>=1.70.0,<1.82.7",  # pinned to avoid PYSEC-2026-2 supply-chain compromise (1.82.7/1.82.8 were malicious)
+    "litellm>=1.70.0,!=1.82.7,!=1.82.8",  # pinned to avoid PYSEC-2026-2 supply-chain compromise (1.82.7/1.82.8 were malicious)
     "python-dotenv>=1.0.0",
     "openai>=1.0.0",
     "jsonschema>=4.25.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # OpenSpace core dependencies
-litellm>=1.70.0,<1.82.7  # pinned to avoid PYSEC-2026-2 supply-chain compromise (1.82.7/1.82.8 were malicious)
+litellm>=1.70.0,!=1.82.7,!=1.82.8  # pinned to avoid PYSEC-2026-2 supply-chain compromise (1.82.7/1.82.8 were malicious)
 python-dotenv>=1.0.0
 openai>=1.0.0
 jsonschema>=4.25.0

--- a/tests/test_litellm_pin_window.py
+++ b/tests/test_litellm_pin_window.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_litellm_pin_window_matches_safe_versions() -> None:
+    pyproject = Path("pyproject.toml").read_text()
+    requirements = Path("requirements.txt").read_text()
+    expected = "litellm>=1.70.0,!=1.82.7,!=1.82.8"
+
+    assert expected in pyproject
+    assert expected in requirements
+    assert "litellm>=1.70.0,<1.82.7" not in pyproject
+    assert "litellm>=1.70.0,<1.82.7" not in requirements


### PR DESCRIPTION
## Summary

- allow safe litellm releases after 1.82.8 while still excluding the malicious 1.82.7/1.82.8 window
- keep `pyproject.toml` and `requirements.txt` aligned
- add a regression test for the dependency window

Fixes #85.

## Validation

- `python3 -m pytest tests/test_litellm_pin_window.py -q`
