### PR TITLE
fix(skill_engine): serialize non-string frontmatter scalars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/benchmarks/terminal_bench/*
 !tests/skill_engine/
 tests/skill_engine/*
 !tests/skill_engine/test_skill_trust_lifecycle.py
+!tests/skill_engine/test_normalize_frontmatter.py
 !tests/skill_engine/test_evolver_length_recovery.py
 !tests/skill_engine/test_evolution_retry_idempotency.py
 !tests/skill_engine/test_analyzer_length_recovery.py

--- a/openspace/skill_engine/skill_utils.py
+++ b/openspace/skill_engine/skill_utils.py
@@ -64,6 +64,27 @@ def _yaml_quote(value: str) -> str:
     return f'"{escaped}"'
 
 
+def _format_frontmatter_value(value: Any) -> str:
+    """Serialize a frontmatter value for re-emit after PyYAML parse."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return _yaml_quote(value)
+    try:
+        import yaml
+
+        dumped = yaml.safe_dump(
+            value, default_flow_style=True, allow_unicode=True
+        ).strip()
+        return dumped
+    except Exception:
+        return _yaml_quote(str(value))
+
+
 def _yaml_unquote(value: str) -> str:
     """Strip surrounding quotes and unescape a YAML scalar value."""
     if len(value) >= 2:
@@ -180,7 +201,7 @@ def normalize_frontmatter(content: str) -> str:
     if not fm:
         return content
 
-    safe_lines = [f"{k}: {_yaml_quote(v)}" for k, v in fm.items()]
+    safe_lines = [f"{k}: {_format_frontmatter_value(v)}" for k, v in fm.items()]
     new_fm = "\n".join(safe_lines)
     return f"---\n{new_fm}\n---{content[match.end():]}"
 

--- a/openspace/skill_engine/skill_utils.py
+++ b/openspace/skill_engine/skill_utils.py
@@ -66,23 +66,14 @@ def _yaml_quote(value: str) -> str:
 
 def _format_frontmatter_value(value: Any) -> str:
     """Serialize a frontmatter value for re-emit after PyYAML parse."""
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if value is None:
-        return "null"
-    if isinstance(value, (int, float)):
-        return str(value)
     if isinstance(value, str):
         return _yaml_quote(value)
-    try:
-        import yaml
+    import yaml
 
-        dumped = yaml.safe_dump(
-            value, default_flow_style=True, allow_unicode=True
-        ).strip()
-        return dumped
-    except Exception:
-        return _yaml_quote(str(value))
+    # First line only: scalar dumps include a trailing '...' document end.
+    return yaml.safe_dump(
+        value, default_flow_style=True, allow_unicode=True
+    ).splitlines()[0]
 
 
 def _yaml_unquote(value: str) -> str:
@@ -185,9 +176,9 @@ def normalize_frontmatter(content: str) -> str:
     """Re-serialize frontmatter with proper YAML quoting.
 
     Parses the existing frontmatter, then re-writes each value through
-    :func:`_yaml_quote` so that colons, hashes, and other special
-    characters are safely double-quoted.  The body after ``---`` is
-    preserved verbatim.
+    :func:`_format_frontmatter_value` so scalars (bool/int/date) and
+    strings with special characters re-emit safely.  The body after
+    ``---`` is preserved verbatim.
 
     Returns *content* unchanged if no frontmatter is found.
     """

--- a/tests/skill_engine/test_normalize_frontmatter.py
+++ b/tests/skill_engine/test_normalize_frontmatter.py
@@ -11,6 +11,15 @@ def test_normalize_frontmatter_bool_and_int_scalars() -> None:
     assert "enabled: true" in out
     assert "version: 2" in out
     assert "# body" in out
+    assert "..." not in out
+
+
+def test_normalize_frontmatter_date_scalar_no_document_end() -> None:
+    raw = "---\nname: demo\ncreated: 2024-01-01\nenabled: true\n---\n"
+    out = normalize_frontmatter(raw)
+    assert "created: 2024-01-01" in out
+    assert "..." not in out
+    assert "enabled: true" in out
 
 
 def test_normalize_frontmatter_string_still_quoted_when_needed() -> None:

--- a/tests/skill_engine/test_normalize_frontmatter.py
+++ b/tests/skill_engine/test_normalize_frontmatter.py
@@ -1,0 +1,19 @@
+"""Regression: normalize_frontmatter must accept non-string YAML scalars."""
+
+from __future__ import annotations
+
+from openspace.skill_engine.skill_utils import normalize_frontmatter
+
+
+def test_normalize_frontmatter_bool_and_int_scalars() -> None:
+    raw = "---\nname: demo\nenabled: true\nversion: 2\n---\n# body\n"
+    out = normalize_frontmatter(raw)
+    assert "enabled: true" in out
+    assert "version: 2" in out
+    assert "# body" in out
+
+
+def test_normalize_frontmatter_string_still_quoted_when_needed() -> None:
+    raw = "---\nname: demo\ndesc: has: colon\n---\n"
+    out = normalize_frontmatter(raw)
+    assert 'desc: "has: colon"' in out


### PR DESCRIPTION
`normalize_frontmatter` re-emits SKILL.md YAML after PyYAML parse. Valid scalars such as `enabled: true` and `created: 2024-01-01` became bool/int/date objects, then `_yaml_quote` raised `TypeError` (or a date dump leaked a `...` document end into the file).

Non-string values now go through `yaml.safe_dump(...).splitlines()[0]`; strings still use `_yaml_quote`.

Repro: `normalize_frontmatter("---\\nname: demo\\nenabled: true\\n---\\n")` TypeError'd on main and now re-emits `enabled: true`.