### PR TITLE
fix(skill_engine): read block-scalar values in get_frontmatter_field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tests/skill_engine/*
 !tests/skill_engine/test_evolver_length_recovery.py
 !tests/skill_engine/test_evolution_retry_idempotency.py
 !tests/skill_engine/test_analyzer_length_recovery.py
+!tests/skill_engine/test_get_frontmatter_block_scalar.py
 !tests/skill_engine/decision/
 tests/skill_engine/decision/*
 !tests/skill_engine/decision/test_analysis_adapter.py

--- a/openspace/skill_engine/skill_utils.py
+++ b/openspace/skill_engine/skill_utils.py
@@ -113,15 +113,30 @@ def get_frontmatter_field(content: str, field_name: str) -> Optional[str]:
     """Extract a single field value from YAML frontmatter.
 
     Returns ``None`` if the field is absent or content has no frontmatter.
-    Uses :func:`parse_frontmatter` so block scalars (``|`` / ``>``) round-trip.
+    Block scalars (``|`` / ``>``) include following indented lines.
     """
-    fm = parse_frontmatter(content)
-    if field_name not in fm:
+    if not content.startswith("---"):
         return None
-    value = fm[field_name]
-    if value is None:
+    match = _FRONTMATTER_RE.match(content)
+    if not match:
         return None
-    return value if isinstance(value, str) else str(value)
+    lines = match.group(1).split("\n")
+    for i, line in enumerate(lines):
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        if key.strip() != field_name:
+            continue
+        rest = value.strip()
+        if re.fullmatch(r"[|>][+-]?", rest):
+            collected: List[str] = []
+            j = i + 1
+            while j < len(lines) and lines[j].startswith((" ", "\t")):
+                collected.append(re.sub(r"^[ \t]+", "", lines[j], count=1))
+                j += 1
+            return "\n".join(collected)
+        return _yaml_unquote(rest)
+    return None
 
 
 def set_frontmatter_field(content: str, field_name: str, value: str) -> str:

--- a/openspace/skill_engine/skill_utils.py
+++ b/openspace/skill_engine/skill_utils.py
@@ -113,18 +113,15 @@ def get_frontmatter_field(content: str, field_name: str) -> Optional[str]:
     """Extract a single field value from YAML frontmatter.
 
     Returns ``None`` if the field is absent or content has no frontmatter.
+    Uses :func:`parse_frontmatter` so block scalars (``|`` / ``>``) round-trip.
     """
-    if not content.startswith("---"):
+    fm = parse_frontmatter(content)
+    if field_name not in fm:
         return None
-    match = _FRONTMATTER_RE.match(content)
-    if not match:
+    value = fm[field_name]
+    if value is None:
         return None
-    for line in match.group(1).split("\n"):
-        if ":" in line:
-            key, value = line.split(":", 1)
-            if key.strip() == field_name:
-                return _yaml_unquote(value.strip())
-    return None
+    return value if isinstance(value, str) else str(value)
 
 
 def set_frontmatter_field(content: str, field_name: str, value: str) -> str:

--- a/tests/skill_engine/test_get_frontmatter_block_scalar.py
+++ b/tests/skill_engine/test_get_frontmatter_block_scalar.py
@@ -1,0 +1,15 @@
+"""Regression: get_frontmatter_field must read YAML block scalars."""
+
+from __future__ import annotations
+
+from openspace.skill_engine.skill_utils import get_frontmatter_field
+
+
+def test_get_frontmatter_field_reads_block_scalar_description():
+    src = "---\nname: x\ndescription: |\n  line1\n  line2\n---\nbody\n"
+    assert get_frontmatter_field(src, "description") == "line1\nline2"
+
+
+def test_get_frontmatter_field_missing_returns_none():
+    src = "---\nname: x\n---\n"
+    assert get_frontmatter_field(src, "description") is None

--- a/tests/skill_engine/test_get_frontmatter_block_scalar.py
+++ b/tests/skill_engine/test_get_frontmatter_block_scalar.py
@@ -10,6 +10,16 @@ def test_get_frontmatter_field_reads_block_scalar_description():
     assert get_frontmatter_field(src, "description") == "line1\nline2"
 
 
+def test_get_frontmatter_field_reads_folded_scalar():
+    src = "---\nname: x\ndescription: >\n  line1\n  line2\n---\n"
+    assert get_frontmatter_field(src, "description") == "line1\nline2"
+
+
 def test_get_frontmatter_field_missing_returns_none():
     src = "---\nname: x\n---\n"
     assert get_frontmatter_field(src, "description") is None
+
+
+def test_get_frontmatter_field_keeps_plain_scalar_text():
+    src = "---\nenabled: true\n---\n"
+    assert get_frontmatter_field(src, "enabled") == "true"


### PR DESCRIPTION
## Problem

`get_frontmatter_field` returned the literal `|` for `description: |` block scalars, so callers skipped filling a real description.

## Repro

```python
from openspace.skill_engine.skill_utils import get_frontmatter_field

src = "---\nname: x\ndescription: |\n  line1\n  line2\n---\n"
assert get_frontmatter_field(src, "description") == "line1\nline2"
```

## Fix

Collect indented continuation lines for `|` / `>` markers in the existing line walker (works without PyYAML; plain scalars unchanged).