### PR TITLE
fix(skill_engine): parse skill-selection JSON despite trailing brace prose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ tests/skill_engine/*
 !tests/skill_engine/test_evolver_length_recovery.py
 !tests/skill_engine/test_evolution_retry_idempotency.py
 !tests/skill_engine/test_analyzer_length_recovery.py
+!tests/skill_engine/test_registry_skill_selection_json.py
 !tests/skill_engine/decision/
 tests/skill_engine/decision/*
 !tests/skill_engine/decision/test_analysis_adapter.py

--- a/openspace/skill_engine/registry.py
+++ b/openspace/skill_engine/registry.py
@@ -1888,13 +1888,13 @@ IMPORTANT: Use the **exact skill_id** from the list above."""
         if code_block:
             content = code_block.group(1).strip()
         else:
-            # Try to find a raw JSON object
-            json_match = re.search(r"\{.*\}", content, re.DOTALL)
-            if json_match:
-                content = json_match.group()
+            # Prefer the first object start; raw_decode ignores trailing prose.
+            brace = content.find("{")
+            if brace >= 0:
+                content = content[brace:]
 
         try:
-            data = json.loads(content)
+            data, _ = json.JSONDecoder().raw_decode(content)
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse LLM skill selection JSON: {content[:200]}")
             return [], ""

--- a/tests/skill_engine/test_registry_skill_selection_json.py
+++ b/tests/skill_engine/test_registry_skill_selection_json.py
@@ -1,0 +1,12 @@
+"""Regression: trailing prose with braces must not drop skill-selection JSON."""
+
+from __future__ import annotations
+
+from openspace.skill_engine.registry import SkillRegistry
+
+
+def test_parse_skill_selection_tolerates_trailing_prose_braces():
+    text = '{"brief_plan": "ok", "skills": ["a"]}\n\nnote {x}'
+    ids, plan = SkillRegistry._parse_skill_selection_response(text)
+    assert ids == ["a"]
+    assert plan == "ok"


### PR DESCRIPTION
## Problem

`SkillRegistry._parse_skill_selection_response` used a greedy `\{.*\}` match before `json.loads`. When the LLM returned valid skill-selection JSON followed by prose that contained braces, the match swallowed the trailing text, parsing failed, and selection returned empty (`[], ""`).

## Repro

```python
from openspace.skill_engine.registry import SkillRegistry

text = '{"brief_plan": "ok", "skills": ["a"]}\n\nnote {x}'
print(SkillRegistry._parse_skill_selection_response(text))
# before: ([], '')
# after:  (['a'], 'ok')
```

## Fix

Find the first `{` and use `json.JSONDecoder().raw_decode`, matching the analyzer/capture parsers.

## Test

`pytest tests/skill_engine/test_registry_skill_selection_json.py -q`